### PR TITLE
Update embedded-hal Dependency to 0.2.3 and and Use digital::v2 Trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/pcein/adc-mcp3008"
 readme = "quickstart.md"
 
 [dependencies]
-embedded-hal = "0.1.0"
+embedded-hal = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adc-mcp3008"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Pramode <mail@pramode.in>"]
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["embedded-hal-driver", "adc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,19 +2,27 @@
 //!
 //! This driver was built using [`embedded-hal`] traits.
 //!
-//! [`embedded-hal`]: https://docs.rs/embedded-hal/~0.1
+//! [`embedded-hal`]: https://docs.rs/embedded-hal/~0.2.3
 //!
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(unsize)]
 #![no_std]
 
 extern crate embedded_hal as hal;
 
 use hal::blocking::spi::Transfer;
+use hal::digital::v2::OutputPin;
 use hal::spi::{Mode, Phase, Polarity};
-use hal::digital::OutputPin;
+
+/// Error
+#[derive(Debug)]
+pub enum Error<CommE, PinE> {
+    /// Communication error
+    Comm(CommE),
+    /// Pin setting error
+    Pin(PinE),
+}
 
 /// SPI mode
 pub const MODE: Mode = Mode {
@@ -34,58 +42,60 @@ pub struct Mcp3004<SPI, CS> {
     cs: CS,
 }
 
-impl<SPI, CS, E> Mcp3008<SPI, CS>
-    where SPI: Transfer<u8, Error = E>,
-          CS: OutputPin
+impl<SPI, CS, CommE, PinE> Mcp3008<SPI, CS>
+where
+    SPI: Transfer<u8, Error = CommE>,
+    CS: OutputPin<Error = PinE>,
 {
     /// Creates a new driver from an SPI peripheral and a chip select
     /// digital I/O pin.
-    pub fn new(spi: SPI, cs: CS) -> Result<Self, E> {
-        let mcp3008 = Mcp3008 { spi: spi, cs: cs };
+    pub fn new(spi: SPI, cs: CS) -> Result<Self, Error<CommE, PinE>> {
+        let mcp3008 = Mcp3008 { spi, cs };
 
         Ok(mcp3008)
     }
 
     /// Read a MCP3008 ADC channel and return the 10 bit value as a u16
-    pub fn read_channel(&mut self, ch: Channels8) -> Result<u16, E> {
-        self.cs.set_low();
+    pub fn read_channel(&mut self, ch: Channels8) -> Result<u16, Error<CommE, PinE>> {
+        self.cs.set_low().map_err(Error::Pin)?;
 
         let mut buffer = [0u8; 3];
         buffer[0] = 1;
         buffer[1] = ((1 << 3) | (ch as u8)) << 4;
 
-        self.spi.transfer(&mut buffer)?;
+        self.spi.transfer(&mut buffer).map_err(Error::Comm)?;
 
-        self.cs.set_high();
+        self.cs.set_high().map_err(Error::Pin)?;
 
         let r = (((buffer[1] as u16) << 8) | (buffer[2] as u16)) & 0x3ff;
         Ok(r)
     }
 }
 
-impl<SPI, CS, E> Mcp3004<SPI, CS>
-    where SPI: Transfer<u8, Error = E>,
-          CS: OutputPin
+impl<SPI, CS, CommE, PinE> Mcp3004<SPI, CS>
+where
+    SPI: Transfer<u8, Error = CommE>,
+    CS: OutputPin<Error = PinE>,
 {
-    /// Creates a new driver from an SPI peripheral and a chip select 
+    /// Creates a new driver from an SPI peripheral and a chip select
     /// digital I/O pin.
-    pub fn new(spi: SPI, cs: CS) -> Result<Self, E> {
-        let mcp3004 = Mcp3004 { spi: spi, cs: cs };
+    pub fn new(spi: SPI, cs: CS) -> Result<Self, Error<CommE, PinE>> {
+        let mcp3004 = Mcp3004 { spi, cs };
 
         Ok(mcp3004)
     }
 
     /// Read a MCP3004 ADC channel and return the 10 bit value as a u16
-    pub fn read_channel(&mut self, ch: Channels4) -> Result<u16, E> {
-        self.cs.set_low();
+    pub fn read_channel(&mut self, ch: Channels4) -> Result<u16, Error<CommE, PinE>> {
+        self.cs.set_low().map_err(Error::Pin)?;
 
         let mut buffer = [0u8; 3];
         buffer[0] = 1;
         buffer[1] = ((1 << 3) | (ch as u8)) << 4;
 
-        self.spi.transfer(&mut buffer)?;
+        self.spi.transfer(&mut buffer).map_err(Error::Comm)?;
 
-        self.cs.set_high();
+        self.cs.set_high().map_err(Error::Pin)?;
 
         let r = (((buffer[1] as u16) << 8) | (buffer[2] as u16)) & 0x3ff;
         Ok(r)


### PR DESCRIPTION
## Description

Due to the dependency, it is currently not possible to use the recent version of hal crates that depend on `embedded-hal = 0.2.3`.

This pull request bumps `embedded-hal` dependency to 0.2.3 and uses `hal::digital::v2::OutputPin` instead of now deprecated `embedded-hal::digital::OutputPin`. 
## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

I have tested on STM32F3Discovery.

- [x] STM32F3Discovery + `stm32f3xx_hal` version 0.4.3 ([Code](https://gist.github.com/lonesometraveler/ad400ac29a29e56a594084016813332d))